### PR TITLE
run after_hooks only if non-empty

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -130,7 +130,7 @@ module Watir
         end
       end
 
-      browser.after_hooks.run
+      browser.after_hooks.run unless browser.after_hooks.length == 0
     end
 
     #


### PR DESCRIPTION
Previously, when the code was `run_checkers`, if an element had no error_checkers -or after_hooks- an empty array would be returned.  Now, instead, `nil` is returned.  This propagates to hangups in test_helper methods that provide wait functionality based on the `click` method